### PR TITLE
Fix lowercasing commands + bot messages being picked up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ config.json
 cookies.txt
 active/*
 
+venv/
+
 hi.mp4

--- a/discordBot.py
+++ b/discordBot.py
@@ -301,6 +301,9 @@ async def parse_command(message):
     if message.author.id == bot.user.id and not '║' in message.content:
         return
     
+    if message.author.bot:
+        return
+
     original_msg = message.content
     msg = message.content.split('║', 1)[0]
     if len(msg) == 0: return
@@ -341,7 +344,7 @@ async def parse_command(message):
         remainder = f"destroy {remainder}"
     
     spl = command.strip().split(' ', 1)
-    cmd  = spl[0].strip().lower()
+    cmd  = spl[0].strip()#.lower()
     args = spl[1].strip() if len(spl) > 1 else ""
     
     final_command_name = None

--- a/discordBot.py
+++ b/discordBot.py
@@ -298,11 +298,9 @@ def process_result_post(msg, res, filename = "video.mp4", prefix = None, random_
         messageQue.append(qued_msg(context = msg, message = res.message, reply = True))
 
 async def parse_command(message):
-    if message.author.id == bot.user.id and not '║' in message.content:
+    if (message.author.id == bot.user.id and not '║' in message.content) or message.author.bot:
         return
     
-    if message.author.bot:
-        return
 
     original_msg = message.content
     msg = message.content.split('║', 1)[0]

--- a/discordBot.py
+++ b/discordBot.py
@@ -298,9 +298,8 @@ def process_result_post(msg, res, filename = "video.mp4", prefix = None, random_
         messageQue.append(qued_msg(context = msg, message = res.message, reply = True))
 
 async def parse_command(message):
-    if (message.author.id == bot.user.id and not '║' in message.content) or message.author.bot:
+    if (message.author.id == bot.user.id and not '║' in message.content) or (message.author.bot and message.author.id != bot.user.id):
         return
-    
 
     original_msg = message.content
     msg = message.content.split('║', 1)[0]


### PR DESCRIPTION
I have fixed two problems I faced hosting this bot, first one being the fact that YouTube IDs for the music command would be put in lowercase, and the second being that the bot could pick up messages from other bots.
<img width="616" alt="image" src="https://github.com/GanerCodes/videoEditBot/assets/23375596/0901f7c2-d2eb-4ddd-a5f3-9f87178d3260">

Because the cmd variable would be put in lowercase, all the arguments from the message are in lowercase, including YouTube IDs from URLs that can be used in the music command. This doesn't look like it affects the download function of the bot. Because the bot looks for command words in lowercase (this is hardcoded), I couldn't just leave the message parsed like so: `Musicskip=2.0, Speed=2.0` - because the bot is looking for lowercase words. Fortunately, this was already a feature of `phraseArgs()`, so I only had to disable lowercasing for `cmd`.

I have fixed these issues mentioned above & have added a venv folder to the .gitignore for convenience.