### PR TITLE
Downgrade pillow so commands like 'caption' can run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ffmpeg-python
 discord.py
 pyjson5
 psutil
-Pillow
+Pillow==9.5.0
 yt-dlp
 pydub
 requests


### PR DESCRIPTION
This fixes the error `object 'ImageDraw' has no attribute 'textsize'` that occurs when running commands like caption, toptext and bottomtext. See: https://groups.google.com/g/weewx-user/c/4qz0bwgna7g?pli=1

![image](https://github.com/GanerCodes/videoEditBot/assets/23375596/527e158b-5ea2-4730-be38-fe5884cdf6ac)
When using a modified version of the bot code that returns error messages, I get the error:
![image](https://github.com/GanerCodes/videoEditBot/assets/23375596/aebd79e4-5d3e-4022-99e8-038b472e464a)
